### PR TITLE
[application] Remove dataclassy and replace with stock dataclasses

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-plugins = dataclassy.mypy
 
 [mypy-orjson.*]
 # https://github.com/toumorokoshi/deepmerge/issues/27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors  = [
 requires-python = ">=3.8"
 dependencies = [
     "colorlog",
-    "dataclassy",
     "deepmerge>=2.0",
     "pyaml",
 ]

--- a/src/pillar/application.py
+++ b/src/pillar/application.py
@@ -2,6 +2,7 @@
 ### ============================================================================
 ## Standard Library
 import argparse
+import dataclasses
 import inspect
 import logging
 import logging.handlers
@@ -17,16 +18,16 @@ import __main__
 
 ## Installed
 import colorlog
-import dataclassy
 
 ## Application
 from .config import ConfigLoader
+from .dataclass import dataclass_slots_kwargs
 from .logging import LoggingMixin, get_log_level, logging_file_handler_errors_kwargs
 
 
 ### CLASSES
 ### ============================================================================
-@dataclassy.dataclass(slots=True)  # pylint: disable=unexpected-keyword-arg
+@dataclasses.dataclass(**dataclass_slots_kwargs())
 class LoggingManifest:
     """Simplified configuration of an `Application`'s logging.
 
@@ -65,7 +66,7 @@ class LoggingManifest:
 
     # General
     default_level: int = logging.INFO
-    additional_namespaces: List[str] = dataclassy.factory(list)
+    additional_namespaces: List[str] = dataclasses.field(default_factory=list)
     # Literal require py38
     # log_format: Literal["text", "json"] = "text"
     # log_format: str = "text"


### PR DESCRIPTION
This resolves cPython 3.14 support as used by nserver, uses the stock dataclass with slots, and preserves python 3.8+ support.
Used the already provided `dataclass_slots_kwargs` function to determine if slots should be enabled.

Resolves #1 
Ran `./dev.sh lint` and `./dev.sh test-full` locally and it passed both.